### PR TITLE
Fix run_continuously in Scheduler

### DIFF
--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -79,7 +79,7 @@ class Scheduler(object):
             @classmethod
             def run(cls):
                 while not cease_continuous_run.is_set():
-                    run_pending()
+                    self.run_pending()
                     time.sleep(interval)
 
         continuous_thread = ScheduleThread()


### PR DESCRIPTION
It would run "run_pending" on the default scheduler.
